### PR TITLE
chore: update runs-on from node12 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ outputs:
   event:
     description: 'The published event as JSON string'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
`node20` has been the default for some time.

Note: [`node22`](https://github.com/actions/runner/issues/3600) not yet supported.